### PR TITLE
Check for user defined timeout

### DIFF
--- a/include/witmotion/message-enumerator.h
+++ b/include/witmotion/message-enumerator.h
@@ -44,6 +44,7 @@ public:
     void Start();
     void SetLog(const QString name);
     void SetInterval(uint32_t ms);
+    void SetTimeout(uint32_t ms);
 public slots:
     void Packet(const witmotion_datapacket& packet);
     void Error(const QString& description);

--- a/include/witmotion/serial.h
+++ b/include/witmotion/serial.h
@@ -25,6 +25,8 @@ private:
     bool validate;
     bool user_defined_return_interval;
     uint32_t return_interval;
+    uint32_t timeout_ms;
+    uint32_t timeout_counter;
 protected:
     QTextStream ttyout;
     QTimer* poll_timer;
@@ -53,6 +55,7 @@ public:
     virtual void Suspend();
     void ValidatePackets(const bool value);
     void SetSensorPollInterval(const uint32_t ms);
+    void SetSensorTimeout(const uint32_t ms);
 };
 
 class QAbstractWitmotionSensorController: public QObject

--- a/include/witmotion/serial.h
+++ b/include/witmotion/serial.h
@@ -25,6 +25,7 @@ private:
     bool validate;
     bool user_defined_return_interval;
     uint32_t return_interval;
+    bool user_defined_timeout;
     uint32_t timeout_ms;
     uint32_t timeout_counter;
 protected:

--- a/src/message-enumerator.cpp
+++ b/src/message-enumerator.cpp
@@ -94,6 +94,11 @@ void QGeneralSensorController::SetInterval(uint32_t ms)
     reader->SetSensorPollInterval(ms);
 }
 
+void QGeneralSensorController::SetTimeout(uint32_t ms)
+{
+    reader->SetSensorTimeout(ms);
+}
+
 void QGeneralSensorController::Packet(const witmotion_datapacket &packet)
 {
     ++packets;

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -16,7 +16,7 @@ void QBaseSerialWitmotionSensorReader::ReadData()
     if((bytes_avail <= 0) && (timeout_ms > 0)) // either zero bytes available, or stream error (bytesAvailable == -1)
     {
         timeout_counter += return_interval;
-        if(timeout_counter > timeout_ms)
+        if(timeout_counter >= timeout_ms)
         {
             emit Error("Timed out waiting for data, please check device connection and baudrate!");
         }
@@ -118,7 +118,8 @@ QBaseSerialWitmotionSensorReader::QBaseSerialWitmotionSensorReader(const QString
     validate(false),
     user_defined_return_interval(false),
     return_interval(50),
-    timeout_ms(1000),
+    user_defined_timeout(false),
+    timeout_ms(150),
     ttyout(stdout),
     poll_timer(nullptr),
     read_state(rsClear),
@@ -156,9 +157,14 @@ void QBaseSerialWitmotionSensorReader::RunPoll()
     poll_timer = new QTimer(this);
     poll_timer->setTimerType(Qt::TimerType::PreciseTimer);
     if(!user_defined_return_interval)
-        poll_timer->setInterval((port_rate == QSerialPort::Baud9600) ? 50 : 30);
-    else
-        poll_timer->setInterval(return_interval);
+    {
+        return_interval = (port_rate == QSerialPort::Baud9600) ? 50 : 30;
+    }
+    poll_timer->setInterval(return_interval);
+    if(!user_defined_timeout)
+    {
+        timeout_ms = 3 * return_interval;
+    }
     timer_connection = connect(poll_timer, &QTimer::timeout, this, &QBaseSerialWitmotionSensorReader::ReadData);
     config_connection = connect(poll_timer, &QTimer::timeout, this, &QBaseSerialWitmotionSensorReader::Configure);
     timeout_counter = 0;
@@ -195,6 +201,7 @@ void QBaseSerialWitmotionSensorReader::SetSensorPollInterval(const uint32_t ms)
 
 void QBaseSerialWitmotionSensorReader::SetSensorTimeout(const uint32_t ms)
 {
+    user_defined_timeout = true;
     timeout_ms = ms;
 }
 


### PR DESCRIPTION
Have made changes to check for a user-defined timeout.  If no timeout defined, then defaults to timeout equal to 3 times the polling interval.  This should replicate the previous repeat-count check approach.