### PR TITLE
GPS measurements decoder fix

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -62,8 +62,8 @@ Here and below, \f$ V \f$ is the **measured** value obtained from the device, \f
 | Temperature | \f$ ^{\circ}C \f$ | \f$ D = \frac{V}{100} \f$ | float |
 | Quaternion component |  | \f$ D = \frac{V}{32768} \f$ | float |
 | Altimetry | \f$ m \f$ | \f$ D = \frac{V}{100} \f$ | float |
-| GPS coordinate, rough/degrees part | \f$ deg \f$ | \f$ D = \frac{V}{10^8} \f$ | double-precision float |
-| GPS coordinate, fine/minute part | \f$ min \f$ | \f$ D = \frac{V \mod 10^7}{10^5} \f$ | double-precision float |
+| GPS coordinate, rough/degrees part | \f$ deg \f$ | \f$ D = \frac{V}{10^7} \f$ | double-precision float |
+| GPS coordinate, fine/minute part | \f$ min \f$ | \f$ D = \frac{V \mod 10^7}{60^6} \f$ | double-precision float |
 | GPS altimetry | \f$ m \f$ | \f$ D = \frac{V}{10} \f$ | float |
 | GPS angular velocity | \f$ rad/s \f$ | \f$ D = \frac{V}{10} \f$ | float |
 | GPS ground speed | \f$ m/s \f$ | \f$ D = \frac{V}{10^3} \f$ | double-precision float |

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -115,8 +115,8 @@ void decode_gps_coord(const int32_t *value,
                       double &deg,
                       double &min)
 {
-    deg = static_cast<double>(*value) / 100000000.f;
-    min = static_cast<double>((*value) % 10000000) / 100000.f;
+    deg = static_cast<double>(*value) / 10000000.f;
+    min = static_cast<double>((*value) % 10000000) / 6000000.f;
 }
 
 /* PACKET DECODERS */


### PR DESCRIPTION
Fixed GPS measurements from the results of tests performed by @joewong00 on WTGAHRS1 enclosed combined GPS/IMU receiver (https://github.com/ElettraSciComp/witmotion_IMU_ros/issues/16#issuecomment-1667218603).

Additional calibrations:
- GPS degrees multiplied by 10
- GPS minutes divided by 60